### PR TITLE
Enable GitHub Pages

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,34 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v3
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: .
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -3,3 +3,11 @@
 A classic retro Snake game built with TypeScript.
 
 🕹 [Play the game](https://<your-username>.github.io/codexplayground2/)
+
+## Enabling GitHub Pages
+
+1. Push this repository to GitHub.
+2. Go to your repository on GitHub and open **Settings** > **Pages**.
+3. Under **Build and deployment**, choose **GitHub Actions** as the source.
+4. Save the settings. GitHub will run the included workflow and publish the site.
+5. Once the workflow completes, the game will be available at `https://<your-username>.github.io/codexplayground2/`.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that deploys the repository via GitHub Pages
- document how to enable GitHub Pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68483b4eaa78832ab6dc5a31bef1bc56